### PR TITLE
Remove subset check of behavior check

### DIFF
--- a/harmony_model_checker/harmony/behavior.py
+++ b/harmony_model_checker/harmony/behavior.py
@@ -156,14 +156,10 @@ def read_hfa(file, dfa, nfa):
             hfa.input_symbols - dfa.input_symbols)
         return
 
-    if is_dfa_equivalent(dfa, hfa):
-        return
-
-    if dfa < hfa:
-        print("behavior warning: strict subset of specified behavior")
+    if not is_dfa_equivalent(dfa, hfa):
+        print("behavior warning: not equivalent to specified behavior")
         diff = hfa - dfa
         behavior_show_diagram(diff, "diff.png")
-        return
 
 # Modified from automata-lib
 def behavior_show_diagram(dfa, path=None):


### PR DESCRIPTION
We don't need to check for subsets for the following reasons:
1. Takes too long.
2. The model checker already implicitly performs a subset check on behaviors.
