### PR TITLE
Fix bug segfault/other memory bugs when concatenating string literals and list literals

### DIFF
--- a/harmony_model_checker/charm/ops.c
+++ b/harmony_model_checker/charm/ops.c
@@ -2207,7 +2207,7 @@ void do_Load(struct state *state, struct step *step,
             unsigned total = vip->size;
             vip++;
             for (unsigned int i = k; i < size; i++, vip++) {
-                if (VALUE_TYPE(indices[k]) != VALUE_ATOM) {
+                if (VALUE_TYPE(indices[i]) != VALUE_ATOM) {
                     char *p = value_string(av);
                     value_ctx_failure(step->ctx, step->allocator, "Load %s: bad string index", p);
                     free(p);
@@ -2253,7 +2253,7 @@ void do_Load(struct state *state, struct step *step,
             unsigned total = vip->size;
             vip++;
             for (unsigned int i = k; i < size; i++, vip++) {
-                if (VALUE_TYPE(indices[k]) != VALUE_LIST) {
+                if (VALUE_TYPE(indices[i]) != VALUE_LIST) {
                     char *p = value_string(av);
                     value_ctx_failure(step->ctx, step->allocator, "Load %s: bad list index", p);
                     free(p);


### PR DESCRIPTION
<!-- IF A SECTION IS NOT APPLICABLE TO YOU, PLEASE DELETE IT!! -->

<!-- Your title should be able to summarize what changes you've made in one sentence. For example: "Exclude staff from the check for follows". For stacked PRs, please indicate clearly in the title where in the stack you are. For example: "[Eatery Refactor][4/5] Converted all files to MVP model" -->


## Overview

<!-- Summarize your changes here. -->

I have found that `print ("abcd" "efg" 1)` crashes Harmony with a cryptic segfault instead of a graceful error. This is related to the string literal+string literal or list literal+list literal concatenation in [ops.c/do_Load](https://github.com/harmonylang/harmony/blob/003a3b38e5eb8984390ac45e15df079f9739850e/harmony_model_checker/charm/ops.c#L2184).

## Changes Made

<!-- Include details of what your changes actually are and how it is intended to work. -->

When checking that the values after the first string are also strings, [the code](https://github.com/harmonylang/harmony/blob/003a3b38e5eb8984390ac45e15df079f9739850e/harmony_model_checker/charm/ops.c#L2209) in `ops.c/do_Load` uses the wrong index variable. So I think the fix is just changing `k` to `i` in two different places (since this bug also affected list literal concatenation).

## Test Coverage

<!-- Describe how you tested this feature. Manual testing and/or unit testing. Please include repro steps and/or how to turn the feature on if applicable. -->

I used manual testing with `print ("abcd" "efg" 1)` or `print ([1, 2, 3] [4, 5, 6] 1)`. If the number is `1` it causes a segfault on my machine. If it's significantly higher it can cause a bus error or silently read memory (I think I tested this last one but I'm not actually sure). 

## ASAN
I found it immensely helpful to be able to run `clang` with its address sanitizer (targeted towards ARM on my Mac, since I couldn't get it working for RISC). Maybe this could be useful to someone else. Please see [`./asan`](https://github.com/a2435191/harmony/blob/dfd0048041e457d11b105ea39127c8542d43feea/asan) and other changes in [my testing repo](https://github.com/a2435191/harmony/blob/dfd0048041e457d11b105ea39127c8542d43feea).
