### PR TITLE
Fix buffer overflow for arity > 16 in Nary ops

### DIFF
--- a/harmony_model_checker/charm/ops.c
+++ b/harmony_model_checker/charm/ops.c
@@ -2477,6 +2477,7 @@ void op_Nary(const void *env, struct state *state, struct step *step){
             }
         }
     }
+    assert(en->arity <= MAX_ARITY); 
     for (unsigned int i = 0; i < en->arity; i++) {
         args[i] = ctx_pop(step->ctx);
         if (step->keep_callstack) {
@@ -2493,6 +2494,7 @@ void op_Nary(const void *env, struct state *state, struct step *step){
             strbuf_printf(&step->explain, "); ");
         }
     }
+    debug("Nary: Executing %d-ary %s\n", en->arity, en->fi->name);
     hvalue_t result = (*en->fi->f)(state, step, args, en->arity);
     if (!step->ctx->failed) {
         if (step->keep_callstack) {
@@ -3422,6 +3424,10 @@ void *init_Nary(struct dict *map, struct allocator *allocator){
     copy[arity->u.atom.len] = 0;
     env->arity = atoi(copy);
     free(copy);
+    if (env->arity > MAX_ARITY) {
+        fprintf(stderr, "Nary: arity %u is too large (> %u)\n", env->arity, MAX_ARITY);
+        exit(1);
+    }
 
     struct json_value *op = dict_lookup(map, "value", 5);
     assert(op->type == JV_ATOM);

--- a/harmony_model_checker/charm/ops.c
+++ b/harmony_model_checker/charm/ops.c
@@ -2494,7 +2494,6 @@ void op_Nary(const void *env, struct state *state, struct step *step){
             strbuf_printf(&step->explain, "); ");
         }
     }
-    debug("Nary: Executing %d-ary %s\n", en->arity, en->fi->name);
     hvalue_t result = (*en->fi->f)(state, step, args, en->arity);
     if (!step->ctx->failed) {
         if (step->keep_callstack) {

--- a/harmony_model_checker/harmony/ast.py
+++ b/harmony_model_checker/harmony/ast.py
@@ -666,6 +666,16 @@ class NaryAST(AST):
         else:
             for i in range(n):
                 self.args[i].compile(scope, code, stmt)
+            # TODO: in the future maybe split into chunks of smaller arity
+            if n > NaryOp.MAX_ARITY:
+                lexeme, file, line, column = self.endtoken # end token looks better imo
+                raise HarmonyCompilerError(
+                    message="Arity %d exceeds max arity %d" % (n, NaryOp.MAX_ARITY),
+                    filename=file,
+                    line=line,
+                    column=column,
+                    lexeme=lexeme
+                )
             code.append(NaryOp(self.op, n), self.token, self.endtoken, stmt=stmt)
 
     def getLabels(self):

--- a/harmony_model_checker/harmony/ops.py
+++ b/harmony_model_checker/harmony/ops.py
@@ -1260,8 +1260,13 @@ class JumpCondOp(Op):
             self.pc = map[self.pc].pc
 
 class NaryOp(Op):
+    # See MAX_ARITY in `ops.c`
+    MAX_ARITY = 16
+    
     def __init__(self, op, n):
+        """Caller should check that n <= MAX_ARITY"""
         self.op = op
+        assert n <= self.MAX_ARITY
         self.n = n
 
     def __repr__(self):


### PR DESCRIPTION
<!-- IF A SECTION IS NOT APPLICABLE TO YOU, PLEASE DELETE IT!! -->

<!-- Your title should be able to summarize what changes you've made in one sentence. For example: "Exclude staff from the check for follows". For stacked PRs, please indicate clearly in the title where in the stack you are. For example: "[Eatery Refactor][4/5] Converted all files to MVP model" -->


## Overview

<!-- Summarize your changes here. -->
Currently, an n-ary operation with n > 16 overflows a buffer.
```
# More than 16 arity causes an unhandled crash
y = 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11 + 12 + 13 + 14 + 15 + 16 + 17
```


## Changes Made

<!-- Include details of what your changes actually are and how it is intended to work. -->

I updated the compiler with an assert in the constructor of `NaryOp` and a graceful compiler error in the one place where the arity isn't known. Since it seems bad to just trust the HVM output, I also added a check in `init_Nary` in `ops.c`, where the JSON data is loaded, and finally an assert right before the place where the buffer overflow actually happened in `op_Nary`.

## [Crash log](https://github.com/a2435191/harmony/tree/44a4584091b0888fbc86e4db7cfc5a6491904701/bad2.asanlog) 

## Test Coverage

<!-- Describe how you tested this feature. Manual testing and/or unit testing. Please include repro steps and/or how to turn the feature on if applicable. -->

I tested the changes by selectively disabling some checks. I wasn't able to test the `assert` though.

## Next Steps

<!-- If this is part of a multi-PR change, please describe what changes you plan on addressing in future PRs. -->

Maybe the compiler could automatically split up ops with arity > 16.

